### PR TITLE
Load vtk.js inside output -- loadvtk() not necessary

### DIFF
--- a/examples/vtktest.jl
+++ b/examples/vtktest.jl
@@ -48,9 +48,6 @@ Julia folder.
 
 """
 
-# ╔═╡ 75fbe996-b746-11eb-3551-c3a5944c312c
-loadvtk()
-
 # ╔═╡ 7c06fcf0-8c98-49f7-add8-435f57a9c9da
 function maketriangulation(maxarea)
 	
@@ -92,7 +89,6 @@ end
 # ╔═╡ Cell order:
 # ╟─93ca4fd0-8f61-4174-b459-55f5395c0f56
 # ╠═d6c0fb79-4129-444a-978a-bd2222b53df6
-# ╠═75fbe996-b746-11eb-3551-c3a5944c312c
 # ╠═7c06fcf0-8c98-49f7-add8-435f57a9c9da
 # ╠═890710fe-dac0-4256-b1ba-79776f1ea7e5
 # ╠═b8a976e3-7fef-4527-ae6a-4da31c93a04f

--- a/src/PlutoVTKPlot.jl
+++ b/src/PlutoVTKPlot.jl
@@ -5,7 +5,7 @@ using UUIDs
 using Colors
 using ColorSchemes
 
-loadvtk()=HTML("""<script type="text/javascript" src="https://unpkg.com/vtk.js"></script>""")
+loadvtk()=error("Deprecated: loadvtk() is now called automatically when you render a plot, you can delete this cell.")
 
 mutable struct VTKPlot
     # command list passed to javascript
@@ -106,6 +106,7 @@ Show plot
 function Base.show(io::IO, ::MIME"text/html", p::VTKPlot)
     vtkplot = read(joinpath(@__DIR__, "..", "assets", "vtkplot.js"), String)
     result="""
+    <script type="text/javascript" src="https://unpkg.com/vtk.js@18"></script>
     <script>
     $(vtkplot)
     const jsdict = $(Main.PlutoRunner.publish_to_js(p.jsdict))


### PR DESCRIPTION
Pluto will automatically 'de-duplicate' JS files that are already loaded, so it's fine to load the same JS source in each output. This means that `loadvtk()` is no longer necessary -- I added a deprecation warning.